### PR TITLE
Make test challenge conditional on UTs passing

### DIFF
--- a/quest/test_challenge.py
+++ b/quest/test_challenge.py
@@ -1,3 +1,5 @@
+import subprocess as sp
+
 from src.data import Dataset
 from src.utils import run_notebook
 from src import paths
@@ -17,6 +19,10 @@ run_notebook(notebook_name="05-Testing-Challenge.ipynb",
              notebook_path=paths['notebook_path'],
              output_notebook_name="05-Testing-Challenge-Test-Run.ipynb",
              output_notebook_path=paths['notebook_path'] / 'test-runs')
+
+# Assess whether unit tests all pass (so clobbered test has been fixed)
+sp.run(["make", "test"]).check_returncode()
+
 
 print("""\n
 ***************************


### PR DESCRIPTION
The latter part of notebook 05 involves having students figure out how to run unit tests, and edit and fix a bug embedded there. The current challenge script does not check that this task has been completed. This PR raises this condition to get the code word for part 5 of the quest. It can be readily discarded if it is considered an *advanced* theme for part 5.