### PR TITLE
Add test_runs directory build if it doesn't exist already

### DIFF
--- a/src/tests/test_ci.py
+++ b/src/tests/test_ci.py
@@ -9,6 +9,7 @@ from src.utils import run_notebook
 from src import paths
 
 notebook_test_path = paths['notebook_path'] / 'test-runs'
+notebook_test_path.mkdir(parents=True, exist_ok=True)
 
 class TestDatasetsSmall(unittest.TestCase):
     """


### PR DESCRIPTION
test_runs doesn't always exist. For example, in CI. Create if needed. This can be resolved properly when https://github.com/hackalog/easydata/issues/232 gets resolved. 